### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project implements a Model Context Protocol (MCP) server to interact with decentralized exchanges (DEXs). It allows MCP-compatible clients (like AI assistants, IDE extensions, or custom applications) to access functionalities such as getting quotes for swaps and executing swaps.
 
+<a href="https://glama.ai/mcp/servers/@IQAIcom/mcp-odos">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@IQAIcom/mcp-odos/badge" alt="MCP-ODOS MCP server" />
+</a>
+
 This server is built using TypeScript and `fastmcp`.
 
 ## Features (MCP Tools)


### PR DESCRIPTION
This PR adds a badge for the [MCP-ODOS](https://glama.ai/mcp/servers/@IQAIcom/mcp-odos) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@IQAIcom/mcp-odos">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@IQAIcom/mcp-odos/badge" alt="MCP-ODOS MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.